### PR TITLE
Projectiles disappear when hitting walls

### DIFF
--- a/TheMagicApprentice/modules/entities/player/player.tscn
+++ b/TheMagicApprentice/modules/entities/player/player.tscn
@@ -355,7 +355,6 @@ _playerHealthComponent = NodePath("../../HealthComponent")
 _spellScene = ExtResource("24_h76h0")
 
 [node name="UI" type="CanvasLayer" parent="."]
-visible = false
 
 [node name="SpellInventory" parent="UI" instance=ExtResource("10_cknrl")]
 

--- a/TheMagicApprentice/modules/entities/player/player.tscn
+++ b/TheMagicApprentice/modules/entities/player/player.tscn
@@ -333,14 +333,14 @@ MagicType = 1
 _playerHealthComponent = NodePath("../../HealthComponent")
 _spellScene = ExtResource("18_gloak")
 
-[node name="StarRain" type="Node" parent="Spells" node_paths=PackedStringArray("_playerHealthComponent") groups=["spell2"]]
+[node name="StarRain" type="Node" parent="Spells" node_paths=PackedStringArray("_playerHealthComponent")]
 script = ExtResource("19_ho7hk")
 BaseDamage = 5.0
 MagicType = 1
 _playerHealthComponent = NodePath("../../HealthComponent")
 _spellScene = ExtResource("20_l7up7")
 
-[node name="DarkEnergyWave" type="Node" parent="Spells" node_paths=PackedStringArray("_playerHealthComponent")]
+[node name="DarkEnergyWave" type="Node" parent="Spells" node_paths=PackedStringArray("_playerHealthComponent") groups=["spell2"]]
 script = ExtResource("21_68wfp")
 BaseDamage = 5.0
 MagicType = 2

--- a/TheMagicApprentice/modules/entities/player/spells/Spell.cs
+++ b/TheMagicApprentice/modules/entities/player/spells/Spell.cs
@@ -13,7 +13,7 @@ public partial class Spell : Area2D
 
 
 	[Export]
-	public double MaxLifeTimeInSeconds = 5.0; ///< How long the spell exists at maximum until it is removed from the world
+	public double MaxLifeTimeInSeconds = 5.0; ///< How long the spell exists at maximum until it is removed from the world, can be changed for every spell in the godot editior
 	public double _timeLeftUntilDeletion; ///< Time left until deletion
 
 	/**

--- a/TheMagicApprentice/modules/entities/player/spells/basic_spell/BasicSpell.cs
+++ b/TheMagicApprentice/modules/entities/player/spells/basic_spell/BasicSpell.cs
@@ -62,7 +62,7 @@ public partial class BasicSpell : Spell
 
 
     /**
-	Gets called when the spell hits a Health component.
+	Gets called when the spell hits a Health component since health components use area2Ds.
 	Since the spells mask layer is set to the enemies layer, it cannot hit the player
 	*/
     public override void OnAreaEntered(Area2D area)
@@ -73,11 +73,19 @@ public partial class BasicSpell : Spell
 			// once the spell has hit something we delete it
 			QueueFree();
 		}
-		// TODO: Spell should also disappear when hitting a wall
 	}
 
-
-
-	
-
+	/**
+	Since parts of the tilemap that have a collision layer are not area2D nodes, body entered is necessary to use.
+	This function detects collisions with all types of 2D nodes.
+	Check if the projectile entered a part of the tilemap, which means a wall or object, and remove the projectile. 
+	This requires mask 1 (Collision) to be set!
+	*/
+	public void OnBodyEntered(Node2D body)
+	{
+		if (body is TileMap)
+		{
+			QueueFree();
+		}
+	}
 }

--- a/TheMagicApprentice/modules/entities/player/spells/basic_spell/basic_spell.tscn
+++ b/TheMagicApprentice/modules/entities/player/spells/basic_spell/basic_spell.tscn
@@ -10,7 +10,7 @@ radius = 16.0312
 modulate = Color(1, 1, 1, 0.784314)
 scale = Vector2(0.25, 0.25)
 collision_layer = 0
-collision_mask = 4
+collision_mask = 5
 script = ExtResource("1_p4fnx")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -18,3 +18,5 @@ shape = SubResource("CircleShape2D_82ati")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 texture = ExtResource("2_2rdec")
+
+[connection signal="body_entered" from="." to="." method="OnBodyEntered"]

--- a/TheMagicApprentice/modules/entities/player/spells/dark_energy_wave/DarkEnergyWave.cs
+++ b/TheMagicApprentice/modules/entities/player/spells/dark_energy_wave/DarkEnergyWave.cs
@@ -23,7 +23,7 @@ public partial class DarkEnergyWave : Spell
     public override void _PhysicsProcess(double delta)
     {
         base._PhysicsProcess(delta);
-		Scale *= (float)1.15; // use the scale property to push the wave
+		Scale *= (float)1.05; // use the scale property to push the wave
     }
 
 

--- a/TheMagicApprentice/modules/entities/player/spells/dark_energy_wave/DarkEnergyWave.cs
+++ b/TheMagicApprentice/modules/entities/player/spells/dark_energy_wave/DarkEnergyWave.cs
@@ -15,6 +15,7 @@ public partial class DarkEnergyWave : Spell
 		base.Init(attack, playerPosition, targetPosition);
 
 		Position = playerPosition;
+		
 	}
 
 	/**
@@ -23,7 +24,7 @@ public partial class DarkEnergyWave : Spell
     public override void _PhysicsProcess(double delta)
     {
         base._PhysicsProcess(delta);
-		Scale *= (float)1.05; // use the scale property to push the wave
+		//Scale *= (float)1.02; // use the scale property to push the wave
     }
 
 
@@ -36,6 +37,7 @@ public partial class DarkEnergyWave : Spell
 		if (area is HealthComponent healthComponent) // check if area is a health component and if true cast it as a healthcomponent under the name healthComponent
 		{
 			healthComponent.TakeDamage(_attack);
+			GD.Print(healthComponent);
 
 			// pushes the enemy. TODO This still need extensive work. We might have to change how movement works. We probably want to use acceleration instead of velocity for movement
 			//(healthComponent.GetParent() as CharacterBody2D).Position += (healthComponent.Position - Position).Normalized() * 40;

--- a/TheMagicApprentice/modules/entities/player/spells/dark_energy_wave/dark_energy_wave.tscn
+++ b/TheMagicApprentice/modules/entities/player/spells/dark_energy_wave/dark_energy_wave.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://dqpjsl8ux75jq"]
+[gd_scene load_steps=5 format=3 uid="uid://dqpjsl8ux75jq"]
 
 [ext_resource type="Script" path="res://modules/entities/player/spells/dark_energy_wave/DarkEnergyWave.cs" id="1_g3318"]
 [ext_resource type="Texture2D" uid="uid://cfga3eogtf0iw" path="res://modules/entities/player/spells/dark_energy_wave/dark_energy_wave.png" id="1_gg2b4"]
@@ -6,16 +6,33 @@
 [sub_resource type="CircleShape2D" id="CircleShape2D_1w8rv"]
 radius = 45.2769
 
+[sub_resource type="Gradient" id="Gradient_en85h"]
+offsets = PackedFloat32Array(0, 0.0666667, 0.4, 0.651852, 0.937037, 0.996296)
+colors = PackedColorArray(0.505882, 0.00392157, 0.890196, 0, 0.50402, 0.00322303, 0.890376, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.50402, 0.00322303, 0.890376, 1, 0.505882, 0.00392157, 0.890196, 0)
+
 [node name="DarkEnergyWave" type="Area2D"]
 modulate = Color(1, 1, 1, 0.784314)
 collision_layer = 0
 collision_mask = 4
 script = ExtResource("1_g3318")
-MaxLifeTimeInSeconds = 0.3
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_1w8rv")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
+visible = false
 scale = Vector2(0.1, 0.1)
 texture = ExtResource("1_gg2b4")
+
+[node name="CPUParticles2D" type="CPUParticles2D" parent="."]
+amount = 1000
+lifetime = 50.0
+explosiveness = 0.98
+direction = Vector2(0, 0)
+spread = 180.0
+gravity = Vector2(0, 0)
+initial_velocity_min = 50.0
+initial_velocity_max = 50.0
+scale_amount_min = 3.0
+scale_amount_max = 5.0
+color_initial_ramp = SubResource("Gradient_en85h")

--- a/TheMagicApprentice/modules/entities/player/spells/star_rain/Star.cs
+++ b/TheMagicApprentice/modules/entities/player/spells/star_rain/Star.cs
@@ -43,7 +43,7 @@ public partial class Star : Spell
 
 
     /**
-	Gets called when the spell hits a Health component.
+	Gets called when the spell hits a Health component since health components use area2Ds.
 	Since the spells mask layer is set to the enemies layer, it cannot hit the player
 	*/
     public override void OnAreaEntered(Area2D area)
@@ -54,6 +54,19 @@ public partial class Star : Spell
 			// once the spell has hit something we delete it
 			QueueFree();
 		}
-		// TODO: Spell should also disappear when hitting a wall
+	}
+
+	/**
+	Since parts of the tilemap that have a collision layer are not area2D nodes, body entered is necessary to use.
+	This function detects collisions with all types of 2D nodes.
+	Check if the projectile entered a part of the tilemap, which means a wall or object, and remove the projectile. 
+	This requires mask 1 (Collision) to be set!
+	*/
+	public void OnBodyEntered(Node2D body)
+	{
+		if (body is TileMap)
+		{
+			QueueFree();
+		}
 	}
 }

--- a/TheMagicApprentice/modules/entities/player/spells/star_rain/star.tscn
+++ b/TheMagicApprentice/modules/entities/player/spells/star_rain/star.tscn
@@ -8,7 +8,7 @@ radius = 4.0
 
 [node name="Star" type="Area2D"]
 collision_layer = 0
-collision_mask = 4
+collision_mask = 5
 script = ExtResource("1_tj5l4")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -18,3 +18,5 @@ shape = SubResource("CircleShape2D_kyivp")
 modulate = Color(0.185319, 3.08037e-06, 0.994769, 1)
 scale = Vector2(0.2, 0.2)
 texture = ExtResource("2_cjge1")
+
+[connection signal="body_entered" from="." to="." method="OnBodyEntered"]

--- a/TheMagicApprentice/modules/entities/slimes/slime-attacks/RangedAttack.cs
+++ b/TheMagicApprentice/modules/entities/slimes/slime-attacks/RangedAttack.cs
@@ -65,21 +65,31 @@ public partial class RangedAttack : Area2D
     }
 
     /**
-	Gets called when the projectile hits a Health component.
-	Since the projectile's mask layer is set to the player layer, it cannot hit other slimes
+	Gets called when the projectile hits a Health component since health components use area2Ds.
+	Since the projectile's mask layer is set to the player layer, it cannot hit other slimes.
 	*/
     public void OnAreaEntered(Area2D area)
 	{
-		GD.Print("hit area");
-		GD.Print(area);
 		if (area is HealthComponent healthComponent) // check if area is a health component and if true cast it as a healthcomponent under the name healthComponent
 		{
 			healthComponent.TakeDamage(_attack);
-
 			// once the spell has hit something we delete it
 			QueueFree();
 		}
-		// TODO: Spell should also disappear when hitting a wall
     }
+
+	/**
+	Since parts of the tilemap that have a collision layer are not area2D nodes, body entered is necessary to use.
+	This function detects collisions with all types of 2D nodes.
+	Check if the projectile entered a part of the tilemap, which means a wall or object, and remove the projectile. 
+	This requires mask 1 (Collision) to be set!
+	*/
+	public void OnBodyEntered(Node2D body)
+	{
+		if (body is TileMap)
+		{
+			QueueFree();
+		}
+	}
 
 }

--- a/TheMagicApprentice/modules/entities/slimes/slime-attacks/RangedAttack.tscn
+++ b/TheMagicApprentice/modules/entities/slimes/slime-attacks/RangedAttack.tscn
@@ -20,3 +20,4 @@ position = Vector2(4, 0)
 shape = SubResource("CircleShape2D_pptpn")
 
 [connection signal="area_entered" from="." to="." method="OnAreaEntered"]
+[connection signal="body_entered" from="." to="." method="OnBodyEntered"]

--- a/TheMagicApprentice/modules/entities/unicorns/unicorn-attacks/ShootingAttackProjectile.cs
+++ b/TheMagicApprentice/modules/entities/unicorns/unicorn-attacks/ShootingAttackProjectile.cs
@@ -77,7 +77,7 @@ public partial class ShootingAttackProjectile : Area2D
     }
 
     /**
-	Gets called when the spell hits a Health component.
+	Gets called when the spell hits a Health component since health components use area2Ds.
 	Projectile mask is set such, that it can only hit the player. 
 	*/
     public void OnAreaEntered(Area2D area)
@@ -88,6 +88,19 @@ public partial class ShootingAttackProjectile : Area2D
 			// once the spell has hit something we delete it
 			QueueFree();
 		}
-		// TODO: Spell should also disappear when hitting a wall
+	}
+
+    /**
+	Since parts of the tilemap that have a collision layer are not area2D nodes, body entered is necessary to use.
+	This function detects collisions with all types of 2D nodes.
+	Check if the projectile entered a part of the tilemap, which means a wall or object, and remove the projectile. 
+	This requires mask 1 (Collision) to be set!
+	*/
+	public void OnBodyEntered(Node2D body)
+	{
+		if (body is TileMap)
+		{
+			QueueFree();
+		}
 	}
 }

--- a/TheMagicApprentice/modules/entities/unicorns/unicorn-attacks/ShootingAttackProjectile.tscn
+++ b/TheMagicApprentice/modules/entities/unicorns/unicorn-attacks/ShootingAttackProjectile.tscn
@@ -8,7 +8,7 @@ radius = 6.0
 
 [node name="ShootingAttackProjectile" type="Area2D"]
 collision_layer = 0
-collision_mask = 2
+collision_mask = 3
 script = ExtResource("1_58o2s")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
@@ -20,3 +20,4 @@ position = Vector2(4, 0)
 shape = SubResource("CircleShape2D_4icen")
 
 [connection signal="area_entered" from="." to="." method="OnAreaEntered"]
+[connection signal="body_entered" from="." to="." method="OnBodyEntered"]

--- a/TheMagicApprentice/modules/entities/unicorns/unicorn.tscn
+++ b/TheMagicApprentice/modules/entities/unicorns/unicorn.tscn
@@ -60,23 +60,19 @@ ChargeAttack = NodePath("../ChargeAttack")
 ShootingAttack = NodePath("../ShootingAttack")
 StompingAttack = NodePath("../StompingAttack")
 
-[node name="ChargeAttack" type="Node" parent="StateMachine" node_paths=PackedStringArray("Wait", "_healthComponent")]
+[node name="ChargeAttack" type="Node" parent="StateMachine" node_paths=PackedStringArray("Wait")]
 script = ExtResource("6_x8tb2")
 Wait = NodePath("../Wait")
-_healthComponent = NodePath("../../HealthComponent")
 
-[node name="ShootingAttack" type="Node" parent="StateMachine" node_paths=PackedStringArray("Wait", "_healthComponent")]
+[node name="ShootingAttack" type="Node" parent="StateMachine" node_paths=PackedStringArray("Wait")]
 script = ExtResource("7_qwsr7")
 Wait = NodePath("../Wait")
 ShootingAnimationDuration = 2.0
-_healthComponent = NodePath("../../HealthComponent")
 
-[node name="StompingAttack" type="Node" parent="StateMachine" node_paths=PackedStringArray("Wait", "_healthComponent")]
+[node name="StompingAttack" type="Node" parent="StateMachine" node_paths=PackedStringArray("Wait")]
 script = ExtResource("8_5d1p3")
 Wait = NodePath("../Wait")
 StompingAnimationDuration = 1.0
-StompingDelayTime = 0.5
-_healthComponent = NodePath("../../HealthComponent")
 
 [node name="Death" type="Node" parent="StateMachine"]
 script = ExtResource("9_i1ral")

--- a/TheMagicApprentice/modules/entities/unicorns/unicorn.tscn
+++ b/TheMagicApprentice/modules/entities/unicorns/unicorn.tscn
@@ -60,19 +60,22 @@ ChargeAttack = NodePath("../ChargeAttack")
 ShootingAttack = NodePath("../ShootingAttack")
 StompingAttack = NodePath("../StompingAttack")
 
-[node name="ChargeAttack" type="Node" parent="StateMachine" node_paths=PackedStringArray("Wait")]
+[node name="ChargeAttack" type="Node" parent="StateMachine" node_paths=PackedStringArray("Wait", "_healthComponent")]
 script = ExtResource("6_x8tb2")
 Wait = NodePath("../Wait")
+_healthComponent = NodePath("../../HealthComponent")
 
-[node name="ShootingAttack" type="Node" parent="StateMachine" node_paths=PackedStringArray("Wait")]
+[node name="ShootingAttack" type="Node" parent="StateMachine" node_paths=PackedStringArray("Wait", "_healthComponent")]
 script = ExtResource("7_qwsr7")
 Wait = NodePath("../Wait")
 ShootingAnimationDuration = 2.0
+_healthComponent = NodePath("../../HealthComponent")
 
-[node name="StompingAttack" type="Node" parent="StateMachine" node_paths=PackedStringArray("Wait")]
+[node name="StompingAttack" type="Node" parent="StateMachine" node_paths=PackedStringArray("Wait", "_healthComponent")]
 script = ExtResource("8_5d1p3")
 Wait = NodePath("../Wait")
 StompingAnimationDuration = 1.0
+_healthComponent = NodePath("../../HealthComponent")
 
 [node name="Death" type="Node" parent="StateMachine"]
 script = ExtResource("9_i1ral")

--- a/TheMagicApprentice/modules/rooms/EnemySpawn.cs
+++ b/TheMagicApprentice/modules/rooms/EnemySpawn.cs
@@ -20,7 +20,7 @@ public partial class EnemySpawn : Node2D
 		Slime slimeInstance = Slime as Slime;
 		if (slimeInstance != null)
 		{
-			slimeInstance.SetSlimeProperties(MagicType.SUN, SlimeSize.SMALL, SlimeAttackRange.MELEE, GlobalPosition, 100);
+			slimeInstance.SetSlimeProperties(MagicType.SUN, SlimeSize.SMALL, SlimeAttackRange.RANGED, GlobalPosition, 100);
 		}
 		RoomHandler.CurrentRoomNode.AddChild(Slime);
 


### PR DESCRIPTION
Changed the four projectiles (unicorn shooting attack projectile, ranged slimes projectiles, basic spell and star rain) such that they despawn when hitting a wall or other terrain parts. 

Other changes:
- Disabled scaling of dark energy wave and added particle system
- Made spell UI visible