### PR TITLE
Move player to global scope

### DIFF
--- a/TheMagicApprentice/main_game.tscn
+++ b/TheMagicApprentice/main_game.tscn
@@ -1,6 +1,5 @@
-[gd_scene load_steps=8 format=3 uid="uid://dua4inolrs6ri"]
+[gd_scene load_steps=7 format=3 uid="uid://dua4inolrs6ri"]
 
-[ext_resource type="PackedScene" uid="uid://cfafpfmqm8u17" path="res://modules/entities/player/player.tscn" id="1_khfie"]
 [ext_resource type="Script" path="res://modules/ui/MainGame.cs" id="1_xal8w"]
 [ext_resource type="Script" path="res://modules/handlers/DungeonHandler.cs" id="2_6yvwo"]
 [ext_resource type="Script" path="res://modules/handlers/RoomHandler.cs" id="3_cd7gp"]
@@ -9,9 +8,6 @@
 [ext_resource type="Script" path="res://modules/handlers/Minimap.cs" id="5_7li43"]
 
 [node name="Scene" type="Node2D"]
-
-[node name="Player" parent="." instance=ExtResource("1_khfie")]
-z_index = 1
 
 [node name="DungeonHandler" type="Node" parent="." groups=["dungeon_handler"]]
 script = ExtResource("2_6yvwo")

--- a/TheMagicApprentice/modules/entities/player/Player.cs
+++ b/TheMagicApprentice/modules/entities/player/Player.cs
@@ -174,4 +174,14 @@ public partial class Player : CharacterBody2D
 		EquipAugmentInSlot(augment, 0);
 
 	}
+
+
+	/**
+	Show the AugmentInventory by setting its visibility to true.
+	Is called by the main hub scirpt when the button to open the menu is pressed
+	*/
+	public void OpenAugmentInventory()
+	{
+		GetNode<AugmentInventory>("AugmentInventory").SetVisibility(true);
+	}
 }

--- a/TheMagicApprentice/modules/entities/player/Player.cs
+++ b/TheMagicApprentice/modules/entities/player/Player.cs
@@ -2,6 +2,13 @@ using Godot;
 using System;
 using System.Linq;
 
+
+/**
+The Player class is the root node of the player scene. It initalizes the Players state machine and then forwards Input, Process and PhysicsProcess to the state machine.
+It also manages the active augments of the player.
+The scene is set as an autoload so that every part of the game can reference it.
+Process is only enabled if the main_game scene is set as active scene in the MenuManager
+*/
 public partial class Player : CharacterBody2D
 {
 	[Export]
@@ -22,6 +29,34 @@ public partial class Player : CharacterBody2D
 		System.Diagnostics.Debug.Assert(StateMachine is not null, "StateMachine in Player is null");
 		System.Diagnostics.Debug.Assert(AnimationPlayer is not null, "AnimationPlayer in Player is null");
 		StateMachine.Init(this, AnimationPlayer);
+
+		// get the MenuManager and connect the MenuChanged signal to the OnMenuChanged function
+		MenuManager menuManager = GetTree().GetFirstNodeInGroup("menu_manager") as MenuManager;
+		if (menuManager is not null) // this is only false for tests and just exists for them
+		{
+			menuManager.MenuChanged += OnMenuChanged;
+		}
+		
+	}
+
+	/**
+	Whenever the menu of the MenuManager changes, this function gets called.
+	If the new menu is the main game scene, we activate ProcessMode and make the UI visible, otherwise we deactivate it and make the UI invisible.
+	*/
+	private void OnMenuChanged(MenuManager.MenuType newMenu, bool isPush)
+	{
+		if (newMenu == MenuManager.MenuType.MainGame)
+		{
+			ProcessMode = ProcessModeEnum.Inherit;
+			//Visible = true;
+			(GetNode("UI") as CanvasLayer).Visible = true;
+		}
+		else
+		{
+			ProcessMode = ProcessModeEnum.Disabled;
+			//Visible = false;
+			(GetNode("UI") as CanvasLayer).Visible = false;
+		}
 	}
 
 	/**

--- a/TheMagicApprentice/modules/entities/player/inventory/augments/AugmentInventory.cs
+++ b/TheMagicApprentice/modules/entities/player/inventory/augments/AugmentInventory.cs
@@ -8,7 +8,7 @@ The AugmentInventory is the root node of the augment inventory.
 It handles the creation of all InventorySlots and the adding of new augments to the inventory.
 */
 [GlobalClass]
-public partial class AugmentInventory : Control
+public partial class AugmentInventory : CanvasLayer
 {
 	[Export]
 	private int _numberOfSlots = 10*7; ///< How many empty slots should be initialized at the start of the game
@@ -47,11 +47,39 @@ public partial class AugmentInventory : Control
 		}
     }
 
+    /**
+	If Esc is pressed the AugmentInventory becomes invisible again and stops processing
+	*/
+    public override void _UnhandledInput(InputEvent @event)
+    {
+        if (@event.IsAction("esc"))
+		{
+			SetVisibility(false);
+		}
+    }
+
 	/**
+	Set the visibility of the AugmentInventory. 
+	Sets the visibility and the ProcessMode.
+	*/
+	public void SetVisibility(bool isVisible)
+	{
+		Visible = isVisible;
+		if (isVisible)
+		{
+			ProcessMode = ProcessModeEnum.Always;
+		}
+		else
+		{
+			ProcessMode = ProcessModeEnum.Disabled;
+		}
+	}
+
+    /**
 	Adds a new augment to the inventory by finding an empty slot in the Grid, creating and InventoryItem with the Augment and putting it in the slot
 	In case all slots are filled it creates a new row of slots in the inventory.
 	*/
-	public void AddAugmentToInventory(Augment augment)
+    public void AddAugmentToInventory(Augment augment)
 	{
 		var inventorySlot = FindEmptyInventorySlot();
         InventoryItem inventoryItem = new InventoryItem

--- a/TheMagicApprentice/modules/entities/player/inventory/augments/AugmentInventory.cs
+++ b/TheMagicApprentice/modules/entities/player/inventory/augments/AugmentInventory.cs
@@ -6,6 +6,9 @@ using System.Linq;
 /**
 The AugmentInventory is the root node of the augment inventory.
 It handles the creation of all InventorySlots and the adding of new augments to the inventory.
+The scene is a child of the player so that it is always loaded as the scene containes all augment data.
+Usually the visibility and the processing is disabled. Except if the player clicks the "Open Augment Inventory" button.
+It can then be closed again using ESC.
 */
 [GlobalClass]
 public partial class AugmentInventory : CanvasLayer
@@ -59,8 +62,7 @@ public partial class AugmentInventory : CanvasLayer
     }
 
 	/**
-	Set the visibility of the AugmentInventory. 
-	Sets the visibility and the ProcessMode.
+	Set the visibility and the ProcessMode of the AugmentInventory. I.e. enable and disable it.
 	*/
 	public void SetVisibility(bool isVisible)
 	{

--- a/TheMagicApprentice/modules/entities/player/inventory/augments/augment_inventory.tscn
+++ b/TheMagicApprentice/modules/entities/player/inventory/augments/augment_inventory.tscn
@@ -2,17 +2,10 @@
 
 [ext_resource type="Script" path="res://modules/entities/player/inventory/augments/AugmentInventory.cs" id="1_u5q8w"]
 
-[node name="AugmentInventory" type="Control"]
-layout_mode = 3
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+[node name="AugmentInventory" type="CanvasLayer"]
 script = ExtResource("1_u5q8w")
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
-layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0

--- a/TheMagicApprentice/modules/entities/player/player.tscn
+++ b/TheMagicApprentice/modules/entities/player/player.tscn
@@ -360,9 +360,12 @@ _spellScene = ExtResource("24_h76h0")
 
 [node name="SpellInventory" parent="UI" instance=ExtResource("10_cknrl")]
 
-[node name="AugmentInventory" parent="UI" instance=ExtResource("25_qc2ug")]
+[node name="AugmentInventory" parent="." instance=ExtResource("25_qc2ug")]
+process_mode = 4
+layer = 10
+visible = false
 
-[node name="AddAugment" type="Button" parent="UI"]
+[node name="AddAugment" type="Button" parent="AugmentInventory"]
 offset_left = 931.0
 offset_top = 15.0
 offset_right = 1144.0
@@ -370,4 +373,4 @@ offset_bottom = 64.0
 focus_mode = 0
 text = "Add Augment to Inventory"
 
-[connection signal="pressed" from="UI/AddAugment" to="UI/AugmentInventory" method="AddRandomAugment"]
+[connection signal="pressed" from="AugmentInventory/AddAugment" to="AugmentInventory" method="AddRandomAugment"]

--- a/TheMagicApprentice/modules/entities/player/player.tscn
+++ b/TheMagicApprentice/modules/entities/player/player.tscn
@@ -239,6 +239,7 @@ radius = 6.0
 height = 20.0
 
 [node name="Player" type="CharacterBody2D" node_paths=PackedStringArray("StateMachine", "AnimationPlayer") groups=["player"]]
+z_index = 10
 script = ExtResource("1_33xnx")
 StateMachine = NodePath("StateMachine")
 AnimationPlayer = NodePath("AnimationPlayer")
@@ -358,7 +359,6 @@ _spellScene = ExtResource("24_h76h0")
 [node name="UI" type="CanvasLayer" parent="."]
 
 [node name="SpellInventory" parent="UI" instance=ExtResource("10_cknrl")]
-visible = false
 
 [node name="AugmentInventory" parent="UI" instance=ExtResource("25_qc2ug")]
 

--- a/TheMagicApprentice/modules/ui/main_hub/MainHub.cs
+++ b/TheMagicApprentice/modules/ui/main_hub/MainHub.cs
@@ -17,4 +17,12 @@ public partial class MainHub : BaseMenu
 	{
 		SetRootMenu(MenuManager.MenuType.MainGame);
 	}
+
+	/**
+	Open the augment inventory by calling the OpenAugmentInventory function of the player which sets the visibility of the Inventory to true
+	*/
+	private void OpenAugmentInventory()
+	{
+		(GetTree().GetFirstNodeInGroup(Globals.PlayerGroup) as Player).OpenAugmentInventory();
+	}
 }

--- a/TheMagicApprentice/modules/ui/main_hub/main_hub.tscn
+++ b/TheMagicApprentice/modules/ui/main_hub/main_hub.tscn
@@ -36,5 +36,14 @@ offset_right = 1050.0
 offset_bottom = 413.0
 text = "Dungeon"
 
+[node name="AugmentInventory" type="Button" parent="Control"]
+layout_mode = 0
+offset_left = 210.0
+offset_top = 113.0
+offset_right = 471.0
+offset_bottom = 220.0
+text = "Open Augment Inventory"
+
 [connection signal="pressed" from="Control/ExitButton" to="." method="OnExitButtonPressed"]
 [connection signal="pressed" from="Control/DungeonButton" to="." method="OnDungeonButtonPressed"]
+[connection signal="pressed" from="Control/AugmentInventory" to="." method="OpenAugmentInventory"]

--- a/TheMagicApprentice/project.godot
+++ b/TheMagicApprentice/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="TheMagicApprentice"
-run/main_scene="res://main_game.tscn"
+run/main_scene="res://main_menu.tscn"
 config/features=PackedStringArray("4.2", "C#", "Forward Plus")
 boot_splash/bg_color=Color(0, 0, 0, 1)
 config/icon="res://icon.svg"

--- a/TheMagicApprentice/project.godot
+++ b/TheMagicApprentice/project.godot
@@ -19,6 +19,7 @@ config/icon="res://icon.svg"
 [autoload]
 
 AugmentManager="*res://modules/augments/AugmentManager.cs"
+Player="*res://modules/entities/player/player.tscn"
 
 [display]
 

--- a/TheMagicApprentice/tests/integration/TestAugmentInventory.cs
+++ b/TheMagicApprentice/tests/integration/TestAugmentInventory.cs
@@ -24,8 +24,10 @@ public partial class TestAugmentInventory
 	[BeforeTest]
 	public void SetupTest()
 	{
-        _mainGameScene = ISceneRunner.Load("res://main_game.tscn");
-        _augmentInventory = _mainGameScene.FindChild("AugmentInventory") as AugmentInventory;
+        _mainGameScene = ISceneRunner.Load("res://modules/entities/player/inventory/augments/augment_inventory.tscn");
+        // sadly again need to use a cursed way to access the root node of the augment_inventory scene since GDUnit4 does not alles easy access
+        var marginContainer = _mainGameScene.FindChild("MarginContainer");
+        _augmentInventory = marginContainer.GetParent() as AugmentInventory;
         AssertObject(_augmentInventory).IsNotNull();
 
         // Assert that there are exactly 5 active slots and at least 10 inactive

--- a/TheMagicApprentice/tests/integration/TestAugments.cs
+++ b/TheMagicApprentice/tests/integration/TestAugments.cs
@@ -4,16 +4,14 @@ using GdUnit4;
 using Godot;
 using System;
 using static GdUnit4.Assertions;
-using GdUnit4.Executions;
-using GdUnit4.Executions.Monitors;
-using System.Threading.Tasks;
 using System.Collections.Generic;
-using System.Linq;
 
 /**
 Integration test for augments
 Contains an integration test for every augment class but not all augments since that would be too much effort
+Uses the main_game.tscn since there the player is autoloaded and not disabled.
 */
+
 [TestSuite]
 public partial class TestAugments
 {
@@ -34,7 +32,11 @@ public partial class TestAugments
     {
         _mainGameScene = ISceneRunner.Load("res://main_game.tscn");
 
-        _player = _mainGameScene.FindChild("Player") as Player;
+        // since player is now an autoload we need some cursed way to access it, since SceneRunner does not support autoloads.
+        var dungeonHandler = _mainGameScene.FindChild("DungeonHandler");
+        System.Diagnostics.Debug.Assert(dungeonHandler is not null, "root is null");
+        _player = dungeonHandler.GetNode<Player>("/root/Player");
+        System.Diagnostics.Debug.Assert(_player is not null, "Player is null");
 
         AssertObject(_player).IsNotNull();
     }


### PR DESCRIPTION
Made the player scene an autoload. That way the player is always loaded. This was also important for all integration tests since all of them require access to the player.
The players ProcessMode and visibility of its UI is disabled if a menu is pushed onto the Menu Stack that is not the main game.
That way the player does not do anything outside the main game.

Changed all integration tests that needed direct access to the player to use the new structure of the scene tree.

Added button to Main Hub that enables the augment inventory. To stop showing the inventory press ESC.