### PR TITLE
Add projectiles and spells to room

### DIFF
--- a/TheMagicApprentice/modules/Globals.cs
+++ b/TheMagicApprentice/modules/Globals.cs
@@ -7,6 +7,7 @@ In particular it conatins all string names for the groups
 public static class Globals
 {
     public const string PlayerGroup = "player"; ///< string name of the group for player
+    public const string RoomHandlerGroup = "room_handler"; ///< string name of the group of the room handler
 
     // group for all InventorySpells
     public const string InventorySpellGroup = "inventory_spell";  ///< string name of the group that contains all inventory spells

--- a/TheMagicApprentice/modules/entities/player/inventory/spells/InventorySpell.cs
+++ b/TheMagicApprentice/modules/entities/player/inventory/spells/InventorySpell.cs
@@ -67,27 +67,29 @@ public partial class InventorySpell : Node
 		AddToGroup(Globals.GetGroupNameOfSpell(_spellName));
     }
 
-
     /**
 	Casts the spell by instanciating the scene and initializing the spell
+	playerPosition and targetPosition are both global coordinates
 	*/
     public virtual void Cast(Vector2 playerPosition, Vector2 targetPosition) 
 	{
-		Spell spell = _spellScene.Instantiate() as Spell;
-		System.Diagnostics.Debug.Assert(spell is not null, "_spellScene is empty, Could not create szene"); // check that it is not null
-
-        Attack attack = new Attack(Damage, MagicType, _playerHealthComponent);
-        spell.Init(attack, playerPosition, targetPosition);
-
-		// TODO in the future do not add to Tree Root but to Room
-        GetTree().Root.AddChild(spell);
-
-		foreach (OnCastAugmentEffect effect in _onCastAugmentEffects)
+		// Get a reference to the current room. The current room is the child of the RoomHandler
+		Node2D room = GetTree().GetFirstNodeInGroup(Globals.RoomHandlerGroup)?.GetChild(0) as Node2D;
+		if (room is not null) // only cast if room exists
 		{
-			effect.OnCast(spell);
+			Spell spell = _spellScene.Instantiate() as Spell;
+			System.Diagnostics.Debug.Assert(spell is not null, "_spellScene is empty, Could not create szene"); // check that it is not null
+
+			Attack attack = new Attack(Damage, MagicType, _playerHealthComponent);
+			spell.Init(attack, playerPosition, targetPosition);
+
+        	room.AddChild(spell);
+			foreach (OnCastAugmentEffect effect in _onCastAugmentEffects)
+			{
+				effect.OnCast(spell);
+			}
 		}
 	}
-
 
 	/**
 	Reset Damage to BaseDamage

--- a/TheMagicApprentice/modules/entities/player/spells/basic_spell/BasicSpell.cs
+++ b/TheMagicApprentice/modules/entities/player/spells/basic_spell/BasicSpell.cs
@@ -23,7 +23,7 @@ public partial class BasicSpell : Spell
 	{
 		base.Init(attack, playerPosition, targetPosition);
 
-		Position = playerPosition;
+		GlobalPosition = playerPosition;
 		_direction = (targetPosition-playerPosition).Normalized();
 
 		LookAt(targetPosition); // make spell look in the correct direction

--- a/TheMagicApprentice/modules/entities/player/spells/black_hole/BlackHole.cs
+++ b/TheMagicApprentice/modules/entities/player/spells/black_hole/BlackHole.cs
@@ -12,6 +12,6 @@ public partial class BlackHole : Spell
 	{
 		base.Init(attack, playerPosition, targetPosition);
 
-		Position = targetPosition;
+		GlobalPosition = targetPosition;
 	}
 }

--- a/TheMagicApprentice/modules/entities/player/spells/dark_energy_wave/DarkEnergyWave.cs
+++ b/TheMagicApprentice/modules/entities/player/spells/dark_energy_wave/DarkEnergyWave.cs
@@ -14,8 +14,7 @@ public partial class DarkEnergyWave : Spell
 	{
 		base.Init(attack, playerPosition, targetPosition);
 
-		Position = playerPosition;
-		
+		GlobalPosition = playerPosition;
 	}
 
 	/**
@@ -26,8 +25,6 @@ public partial class DarkEnergyWave : Spell
         base._PhysicsProcess(delta);
 		//Scale *= (float)1.02; // use the scale property to push the wave
     }
-
-
 
     /**
 	If we hit an enemy we push them back

--- a/TheMagicApprentice/modules/entities/player/spells/moon_light/MoonLight.cs
+++ b/TheMagicApprentice/modules/entities/player/spells/moon_light/MoonLight.cs
@@ -13,6 +13,6 @@ public partial class MoonLight : Spell
 	public override void Init(Attack attack, Vector2 playerPosition, Vector2 targetPosition) 
 	{
 		base.Init(attack, playerPosition, targetPosition);
-		Position = playerPosition;
+		GlobalPosition = playerPosition;
 	}
 }

--- a/TheMagicApprentice/modules/entities/player/spells/star_rain/Star.cs
+++ b/TheMagicApprentice/modules/entities/player/spells/star_rain/Star.cs
@@ -31,7 +31,7 @@ public partial class Star : Spell
 		var rng = new RandomNumberGenerator();
 
 		Vector2 offset = new Vector2(rng.RandfRange(-10, 10),  rng.RandfRange(-10, 10));
-		Position = playerPosition + offset;
+		GlobalPosition = playerPosition + offset;
 		_direction = (targetPosition-playerPosition).Normalized(); // TODO think abouth how to set the direction according to the offset
 
 		LookAt(targetPosition); // make spell look in the correct direction

--- a/TheMagicApprentice/modules/entities/player/spells/summon_sun/Sun.cs
+++ b/TheMagicApprentice/modules/entities/player/spells/summon_sun/Sun.cs
@@ -17,7 +17,7 @@ public partial class Sun : Spell
 		base.Init(attack, playerPosition, targetPosition);
 		_attack.damage /= 60.0;
 
-		Position = targetPosition;
+		GlobalPosition = targetPosition;
 	}
 
 	/**

--- a/TheMagicApprentice/modules/entities/player/spells/sun_beam/SunBeam.cs
+++ b/TheMagicApprentice/modules/entities/player/spells/sun_beam/SunBeam.cs
@@ -12,7 +12,7 @@ public partial class SunBeam : Spell
 	{
 		base.Init(attack, playerPosition, targetPosition);
 
-		Position = playerPosition;
+		GlobalPosition = playerPosition;
 
 		LookAt(targetPosition); // make spell look in the correct direction
 	}

--- a/TheMagicApprentice/modules/entities/player/states/PlayerSpellCasting.cs
+++ b/TheMagicApprentice/modules/entities/player/states/PlayerSpellCasting.cs
@@ -65,7 +65,7 @@ public partial class PlayerSpellCasting : State
         // otherwise cast all spells
         foreach (InventorySpell spell in spells)
         {
-            spell.Cast(Parent.Position, Parent.GetGlobalMousePosition());
+            spell.Cast(Parent.GlobalPosition, Parent.GetGlobalMousePosition());
         }
         // finally retrieve the CastTime from the first spell which is always the main spell
         _timeLeft = spells.First().CastTime;

--- a/TheMagicApprentice/modules/entities/slimes/states/SlimeAttacking.cs
+++ b/TheMagicApprentice/modules/entities/slimes/states/SlimeAttacking.cs
@@ -129,12 +129,17 @@ public partial class SlimeAttacking : State
 	*/
 	private void SpawnRangedAttack(Attack attack)
 	{
-		PackedScene scene = GD.Load<PackedScene>("res://modules/entities/slimes/slime-attacks/RangedAttack.tscn");
-		RangedAttack ranged_attack = scene.Instantiate() as RangedAttack;
-		GetTree().Root.AddChild(ranged_attack); // Add the ranged attack projectile to the scene tree
+		// Get a reference to the current room. The current room is the child of the RoomHandler
+		Node2D room = GetTree().GetFirstNodeInGroup(Globals.RoomHandlerGroup)?.GetChild(0) as Node2D;
+		if (room is not null) // only cast if room exists
+		{
+			PackedScene scene = GD.Load<PackedScene>("res://modules/entities/slimes/slime-attacks/RangedAttack.tscn");
+			RangedAttack ranged_attack = scene.Instantiate() as RangedAttack;
+			room.AddChild(ranged_attack); // Add the ranged attack projectile to the scene tree
 
-		Vector2 vector_to_player = _player.GlobalPosition - Parent.GlobalPosition;
-		ranged_attack.Init(attack, vector_to_player); // initialise the ranged attack with the build attack and the direction from the slime towards the player
-		ranged_attack.Position = Parent.Position; // ranged attack spawns at the position of the slime
+			Vector2 vector_to_player = _player.GlobalPosition - Parent.GlobalPosition;
+			ranged_attack.Init(attack, vector_to_player); // initialise the ranged attack with the build attack and the direction from the slime towards the player
+			ranged_attack.GlobalPosition = Parent.GlobalPosition; // ranged attack spawns at the position of the slime
+		}
 	}
 }

--- a/TheMagicApprentice/modules/entities/unicorns/unicorn-attacks/ShootingAttackProjectileHandler.cs
+++ b/TheMagicApprentice/modules/entities/unicorns/unicorn-attacks/ShootingAttackProjectileHandler.cs
@@ -47,12 +47,17 @@ public partial class ShootingAttackProjectileHandler : Node
 	*/
 	private void SpawnProjectile()
 	{
-		PackedScene scene = GD.Load<PackedScene>("res://modules/entities/unicorns/unicorn-attacks/ShootingAttackProjectile.tscn");
-		ShootingAttackProjectile projectile = scene.Instantiate() as ShootingAttackProjectile;
-		GetTree().Root.AddChild(projectile); // Add the ranged attack projectile to the scene tree
+		// Get a reference to the current room. The current room is the child of the RoomHandler
+		Node2D room = GetTree().GetFirstNodeInGroup(Globals.RoomHandlerGroup)?.GetChild(0) as Node2D;
+		if (room is not null) // only cast if room exists
+		{
+			PackedScene scene = GD.Load<PackedScene>("res://modules/entities/unicorns/unicorn-attacks/ShootingAttackProjectile.tscn");
+			ShootingAttackProjectile projectile = scene.Instantiate() as ShootingAttackProjectile;
+			room.AddChild(projectile); // Add the ranged attack projectile to the scene tree
 
-		projectile.Init(_attack); // Iniitialise the attack such that the projectile can damage the player on impact
-		projectile.Position = _unicornPosition; // ranged attack spawns at the position of the slime
+			projectile.Init(_attack); // Iniitialise the attack such that the projectile can damage the player on impact
+			projectile.GlobalPosition = _unicornPosition; // ranged attack spawns at the position of the slime
+		}
 	}
 
 }

--- a/TheMagicApprentice/tests/integration/TestAugments.cs
+++ b/TheMagicApprentice/tests/integration/TestAugments.cs
@@ -97,9 +97,7 @@ public partial class TestAugments
                 // if augmentEffectIndex is below 0 then the augment is filled and we can move on to the next augment
                 if (augmentEffectIndex < 0)
                 {
-                    _player.EquipAugmentInSlot(augment, _random.Next(5)); ///// WHY IS THERE A PROBELM Herere????????
-
-
+                    _player.EquipAugmentInSlot(augment, _random.Next(5)); 
                     augmentEffectIndex = _random.Next(3);
                 }
                 fileName = directory.GetNext();
@@ -304,7 +302,7 @@ public partial class TestAugments
         blackHole.Cast(Vector2.Zero, Vector2.Down); // Cast the spell so that it is instanciated
 
 		Node2D room = _player.GetTree().GetFirstNodeInGroup(Globals.RoomHandlerGroup)?.GetChild(0) as Node2D;
-        Spell blackHoleSpell = room.GetNode("BlackHole") as Spell; // right now spells get added as children of Root. This might change later!
+        Spell blackHoleSpell = room.GetNode("BlackHole") as Spell;
         AssertObject(blackHoleSpell).IsNotNull();
 
         Vector2 startScale = blackHoleSpell.Scale;
@@ -324,7 +322,7 @@ public partial class TestAugments
         // Cast the spell and check that the scale increased
         blackHole.Cast(Vector2.Zero, Vector2.Down); // Cast the spell so that it is instanciated
 
-        Spell blackHoleSpell2 = room.GetNode("BlackHole") as Spell; // right now spells get added as children of Root. This might change later!
+        Spell blackHoleSpell2 = room.GetNode("BlackHole") as Spell;
         AssertObject(blackHoleSpell2).IsNotNull();
 
         Vector2 newScale = blackHoleSpell2.Scale;
@@ -353,7 +351,7 @@ public partial class TestAugments
         blackHole.Cast(Vector2.Zero, Vector2.Down); // Cast the spell so that it is instanciated
 
         Node2D room = _player.GetTree().GetFirstNodeInGroup(Globals.RoomHandlerGroup)?.GetChild(0) as Node2D;
-        Spell blackHoleSpell = room.GetNode("BlackHole") as Spell; // right now spells get added as children of Root. This might change later!
+        Spell blackHoleSpell = room.GetNode("BlackHole") as Spell; 
         AssertObject(blackHoleSpell).IsNotNull();
 
         double startTimeLeft = blackHoleSpell._timeLeftUntilDeletion;
@@ -372,7 +370,7 @@ public partial class TestAugments
         // Cast the spell and check that the scale increased
         blackHole.Cast(Vector2.Zero, Vector2.Down); // Cast the spell so that it is instanciated
 
-        Spell blackHoleSpell2 = room.GetNode("BlackHole") as Spell; // right now spells get added as children of Root. This might change later!
+        Spell blackHoleSpell2 = room.GetNode("BlackHole") as Spell;
         AssertObject(blackHoleSpell2).IsNotNull();
 
         double newTimeLeft = blackHoleSpell2._timeLeftUntilDeletion;
@@ -430,8 +428,6 @@ public partial class TestAugments
     */
     private void EquipEffect(string effectName)
     {
-        GD.Print("HI");
-        GD.Print(effectName);
         string path = _folderPath + effectName;
         _player.EquipAugmentInSlot(CreateAugmentWithAugmenteffect(path), 0);
     }

--- a/TheMagicApprentice/tests/integration/TestAugments.cs
+++ b/TheMagicApprentice/tests/integration/TestAugments.cs
@@ -97,7 +97,9 @@ public partial class TestAugments
                 // if augmentEffectIndex is below 0 then the augment is filled and we can move on to the next augment
                 if (augmentEffectIndex < 0)
                 {
-                    _player.EquipAugmentInSlot(augment, _random.Next(5));
+                    _player.EquipAugmentInSlot(augment, _random.Next(5)); ///// WHY IS THERE A PROBELM Herere????????
+
+
                     augmentEffectIndex = _random.Next(3);
                 }
                 fileName = directory.GetNext();
@@ -301,7 +303,8 @@ public partial class TestAugments
         // Get the size of the normal Cast BlackHole
         blackHole.Cast(Vector2.Zero, Vector2.Down); // Cast the spell so that it is instanciated
 
-        Spell blackHoleSpell = _player.GetTree().Root.GetNode("BlackHole") as Spell; // right now spells get added as children of Root. This might change later!
+		Node2D room = _player.GetTree().GetFirstNodeInGroup(Globals.RoomHandlerGroup)?.GetChild(0) as Node2D;
+        Spell blackHoleSpell = room.GetNode("BlackHole") as Spell; // right now spells get added as children of Root. This might change later!
         AssertObject(blackHoleSpell).IsNotNull();
 
         Vector2 startScale = blackHoleSpell.Scale;
@@ -321,7 +324,7 @@ public partial class TestAugments
         // Cast the spell and check that the scale increased
         blackHole.Cast(Vector2.Zero, Vector2.Down); // Cast the spell so that it is instanciated
 
-        Spell blackHoleSpell2 = _player.GetTree().Root.GetNode("BlackHole") as Spell; // right now spells get added as children of Root. This might change later!
+        Spell blackHoleSpell2 = room.GetNode("BlackHole") as Spell; // right now spells get added as children of Root. This might change later!
         AssertObject(blackHoleSpell2).IsNotNull();
 
         Vector2 newScale = blackHoleSpell2.Scale;
@@ -349,7 +352,8 @@ public partial class TestAugments
         // Get the size of the normal Cast BlackHole
         blackHole.Cast(Vector2.Zero, Vector2.Down); // Cast the spell so that it is instanciated
 
-        Spell blackHoleSpell = _player.GetTree().Root.GetNode("BlackHole") as Spell; // right now spells get added as children of Root. This might change later!
+        Node2D room = _player.GetTree().GetFirstNodeInGroup(Globals.RoomHandlerGroup)?.GetChild(0) as Node2D;
+        Spell blackHoleSpell = room.GetNode("BlackHole") as Spell; // right now spells get added as children of Root. This might change later!
         AssertObject(blackHoleSpell).IsNotNull();
 
         double startTimeLeft = blackHoleSpell._timeLeftUntilDeletion;
@@ -368,7 +372,7 @@ public partial class TestAugments
         // Cast the spell and check that the scale increased
         blackHole.Cast(Vector2.Zero, Vector2.Down); // Cast the spell so that it is instanciated
 
-        Spell blackHoleSpell2 = _player.GetTree().Root.GetNode("BlackHole") as Spell; // right now spells get added as children of Root. This might change later!
+        Spell blackHoleSpell2 = room.GetNode("BlackHole") as Spell; // right now spells get added as children of Root. This might change later!
         AssertObject(blackHoleSpell2).IsNotNull();
 
         double newTimeLeft = blackHoleSpell2._timeLeftUntilDeletion;
@@ -426,6 +430,8 @@ public partial class TestAugments
     */
     private void EquipEffect(string effectName)
     {
+        GD.Print("HI");
+        GD.Print(effectName);
         string path = _folderPath + effectName;
         _player.EquipAugmentInSlot(CreateAugmentWithAugmenteffect(path), 0);
     }


### PR DESCRIPTION
Projectiles and spells are now added as children of the current room and not the root of the scene tree. Also they are now initilalized with GlobalPosition.

Also fixed tests