### PR TITLE
make menu manager work when starting different scenes

### DIFF
--- a/TheMagicApprentice/main_menu.tscn
+++ b/TheMagicApprentice/main_menu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3 uid="uid://cbmkjb8it4klc"]
+[gd_scene load_steps=2 format=3 uid="uid://bf6qjf7wvm2bt"]
 
 [ext_resource type="Script" path="res://modules/handlers/MenuManager.cs" id="1_2y561"]
 

--- a/TheMagicApprentice/modules/handlers/MenuManager.cs
+++ b/TheMagicApprentice/modules/handlers/MenuManager.cs
@@ -1,6 +1,7 @@
 using Godot;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 /**
  * Manages the menu system for the game.
@@ -49,11 +50,43 @@ public partial class MenuManager : Node
 	
 
 	/**
-	 * Initializes the menu system by pushing the main menu.
+	 * Called when the node is added to the scene tree, adds this node to the menu_manager group.
+	 */
+	public override void _EnterTree()
+	{
+		AddToGroup("menu_manager");
+	}
+
+	/**
+	 * Called when the node is ready.
 	 */
 	public override void _Ready()
 	{
-		PushMenu(MenuType.MainMenu);
+		CheckForExistingMenu();
+	}
+
+	/**
+	 * Checks for an existing menu node in the scene and adds it to the stack and tracking.
+	 */
+	private void CheckForExistingMenu()
+	{
+		// Look for any node that inherits from BaseMenu
+		var existingMenuNode = GetTree().Root.GetChildren()
+			.FirstOrDefault(node => node is BaseMenu) as BaseMenu;
+
+		if (existingMenuNode != null)
+		{
+			// Add the existing menu to our stack and tracking
+			MenuType menuType = existingMenuNode.MenuType;
+			_menuStack.Push(menuType);
+			_menuNodes[menuType] = existingMenuNode;
+			existingMenuNode.CallDeferred("reparent", this);
+		}
+		else
+		{
+			// If no menu exists, destroy this node
+			QueueFree();
+		}
 	}
 
 	/**

--- a/TheMagicApprentice/modules/ui/MenuHub.tscn
+++ b/TheMagicApprentice/modules/ui/MenuHub.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3 uid="uid://mvd4nys3bax6"]
+[gd_scene load_steps=2 format=3 uid="uid://kg2c8qf7u2dj"]
 
 [ext_resource type="Script" path="res://modules/handlers/MenuManager.cs" id="1_yvu67"]
 

--- a/TheMagicApprentice/project.godot
+++ b/TheMagicApprentice/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="TheMagicApprentice"
-run/main_scene="res://main_menu.tscn"
+run/main_scene="res://modules/ui/main_menu/main_menu.tscn"
 config/features=PackedStringArray("4.2", "C#", "Forward Plus")
 boot_splash/bg_color=Color(0, 0, 0, 1)
 config/icon="res://icon.svg"
@@ -20,6 +20,7 @@ config/icon="res://icon.svg"
 
 AugmentManager="*res://modules/augments/AugmentManager.cs"
 Player="*res://modules/entities/player/player.tscn"
+MenuManager="*res://modules/handlers/MenuManager.cs"
 
 [display]
 


### PR DESCRIPTION
menu manager autoloads and therefor works correctly when instantiating different scenes (like main_menu, main_hub, main_game).

new main scene is now `modules/ui/main_menu/main_menu.tscn`