### PR TITLE
Added HP Bar to player end handled player death

### DIFF
--- a/TheMagicApprentice/modules/entities/healthbar/Healthbar.cs
+++ b/TheMagicApprentice/modules/entities/healthbar/Healthbar.cs
@@ -44,10 +44,6 @@ public partial class Healthbar : TextureProgressBar
 		_healthPoints = Math.Min(MaxValue, newHealth);
 		_healthbar.Value = _healthPoints;
 
-		if (_healthPoints <= 0)
-		{
-			QueueFree();
-		}
 		if (_healthPoints < oldHealth)
 		{
 			_timer.Start();

--- a/TheMagicApprentice/modules/entities/player/Player.cs
+++ b/TheMagicApprentice/modules/entities/player/Player.cs
@@ -41,8 +41,29 @@ public partial class Player : CharacterBody2D
 	}
 
 	/**
+	Gets called when HP reach 0.
+	Opens the death screen using CallDeferred
+	*/
+	public void OnPlayerDeath()
+	{
+		CallDeferred(nameof(OpenPlayerDeathMenu));
+	}
+
+	/**
+	Opens the PlayerDeathMenu using the MenuManager
+	*/
+	private void OpenPlayerDeathMenu()
+	{
+		MenuManager menuManager = GetTree().GetFirstNodeInGroup("menu_manager") as MenuManager;
+		System.Diagnostics.Debug.Assert(menuManager is not null, "Cannot find MenuManager when player died");
+
+		menuManager.PushMenu(MenuManager.MenuType.PlayerDeathMenu);
+	}
+
+	/**
 	Whenever the menu of the MenuManager changes, this function gets called.
 	If the new menu is the main game scene, we activate ProcessMode and make the UI visible, otherwise we deactivate it and make the UI invisible.
+	Furthermore, if we enter the MainGame, we reset the hp of the player
 	*/
 	private void OnMenuChanged(MenuManager.MenuType newMenu, bool isPush)
 	{
@@ -51,6 +72,7 @@ public partial class Player : CharacterBody2D
 			ProcessMode = ProcessModeEnum.Inherit;
 			//Visible = true;
 			(GetNode("UI") as CanvasLayer).Visible = true;
+			ResetPlayerHP();
 		}
 		else
 		{
@@ -280,6 +302,7 @@ public partial class Player : CharacterBody2D
 	/**
 	Resets the player scene to the default.
 	Is called whenever a new game is created
+	Currently does not work
 	*/
 	public void ResetPlayer()
 	{
@@ -290,5 +313,13 @@ public partial class Player : CharacterBody2D
 		RemoveFromGroup(Globals.PlayerGroup);
 		GetTree().Root.AddChild(newPlayer);
 		QueueFree();
+	}
+
+	/**
+	Resets the HP of the player
+	*/
+	public void ResetPlayerHP()
+	{
+		GetNode<HealthComponent>("HealthComponent")._Ready(); // the ready function of the healthcomponent resets the HP, that is why we call it there
 	}
 }

--- a/TheMagicApprentice/modules/entities/player/inventory/spell_inventory.tscn
+++ b/TheMagicApprentice/modules/entities/player/inventory/spell_inventory.tscn
@@ -1,11 +1,8 @@
-[gd_scene load_steps=7 format=3 uid="uid://cauv7k1n531by"]
+[gd_scene load_steps=4 format=3 uid="uid://cauv7k1n531by"]
 
 [ext_resource type="Script" path="res://modules/entities/player/inventory/SpellInventory.cs" id="1_f0cmj"]
 [ext_resource type="Theme" uid="uid://b5xmy0ocd4tfb" path="res://assets/themes/ingame_inventory_theme.tres" id="1_qb6us"]
 [ext_resource type="PackedScene" uid="uid://bojweh18kways" path="res://modules/entities/player/inventory/UI_spell_slot.tscn" id="3_n3my7"]
-[ext_resource type="Texture2D" uid="uid://bigsga6igu58y" path="res://modules/entities/player/inventory/spell_icons/sun/sun_basic_spell.png" id="4_e7go7"]
-[ext_resource type="Texture2D" uid="uid://ek035vhcmnxn" path="res://modules/entities/player/inventory/spell_icons/cosmic/star_rain.png" id="5_8phs2"]
-[ext_resource type="Texture2D" uid="uid://biry3omfnf4kg" path="res://modules/entities/player/inventory/spell_icons/sun/sun_beam.png" id="6_cwwwy"]
 
 [node name="SpellInventory" type="Control"]
 layout_mode = 3
@@ -41,16 +38,13 @@ layout_mode = 2
 unique_name_in_owner = true
 custom_minimum_size = Vector2(37, 33)
 layout_mode = 2
-StartingTexture = ExtResource("4_e7go7")
 
 [node name="SpellSlot2" parent="MarginContainer/HBoxContainer" groups=["spell_slot2"] instance=ExtResource("3_n3my7")]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(37, 33)
 layout_mode = 2
-StartingTexture = ExtResource("5_8phs2")
 
 [node name="SpellSlot3" parent="MarginContainer/HBoxContainer" groups=["spell_slot3"] instance=ExtResource("3_n3my7")]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(37, 33)
 layout_mode = 2
-StartingTexture = ExtResource("6_cwwwy")

--- a/TheMagicApprentice/modules/entities/player/player.tscn
+++ b/TheMagicApprentice/modules/entities/player/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=40 format=3 uid="uid://cfafpfmqm8u17"]
+[gd_scene load_steps=41 format=3 uid="uid://cfafpfmqm8u17"]
 
 [ext_resource type="Script" path="res://modules/entities/player/Player.cs" id="1_33xnx"]
 [ext_resource type="PackedScene" uid="uid://b5pdg2ut61woi" path="res://modules/entities/health_component.tscn" id="1_oqun1"]
@@ -21,6 +21,7 @@
 [ext_resource type="PackedScene" uid="uid://cqx4bqlj501rl" path="res://modules/entities/player/inventory/spells/skill_tree.tscn" id="21_73epa"]
 [ext_resource type="AudioStream" uid="uid://duc02tb548k0i" path="res://modules/entities/player/states/walking.mp3" id="21_aqxnf"]
 [ext_resource type="AudioStream" uid="uid://dbqfq2yqv56ax" path="res://modules/entities/player/hit.mp3" id="22_r8oly"]
+[ext_resource type="PackedScene" uid="uid://cqcik8bgxyjjc" path="res://modules/entities/healthbar/healthbar.tscn" id="22_sk64w"]
 [ext_resource type="PackedScene" uid="uid://dqpjsl8ux75jq" path="res://modules/entities/player/spells/dark_energy_wave/dark_energy_wave.tscn" id="22_vkran"]
 [ext_resource type="PackedScene" uid="uid://u23ysmqaadgq" path="res://modules/entities/player/spells/black_hole/black_hole.tscn" id="24_h76h0"]
 [ext_resource type="PackedScene" uid="uid://dbtvjj0ey2g4s" path="res://modules/entities/player/inventory/augments/augment_inventory.tscn" id="25_qc2ug"]
@@ -261,9 +262,10 @@ rotation = 1.5708
 shape = SubResource("CapsuleShape2D_jsldv")
 metadata/_edit_lock_ = true
 
-[node name="HealthComponent" parent="." node_paths=PackedStringArray("HitSound") instance=ExtResource("1_oqun1")]
+[node name="HealthComponent" parent="." node_paths=PackedStringArray("HitSound", "healthbar") instance=ExtResource("1_oqun1")]
 collision_layer = 2
 HitSound = NodePath("../HitSound")
+healthbar = NodePath("../UI/Damagebar")
 metadata/_edit_lock_ = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="HealthComponent"]
@@ -387,6 +389,22 @@ _spellScene = ExtResource("24_h76h0")
 
 [node name="SpellInventory" parent="UI" instance=ExtResource("10_cknrl")]
 
+[node name="Damagebar" parent="UI" instance=ExtResource("22_sk64w")]
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -78.0
+offset_top = -79.0
+offset_right = 2.0
+offset_bottom = -70.0
+grow_horizontal = 2
+grow_vertical = 0
+scale = Vector2(2, 2)
+size_flags_horizontal = 4
+size_flags_vertical = 8
+
 [node name="AugmentInventory" parent="." instance=ExtResource("25_qc2ug")]
 process_mode = 4
 visible = false
@@ -413,4 +431,5 @@ texture = ExtResource("26_vyf6c")
 stream = ExtResource("22_r8oly")
 volume_db = -20.0
 
+[connection signal="Death" from="HealthComponent" to="." method="OnPlayerDeath"]
 [connection signal="pressed" from="AugmentInventory/AddAugment" to="AugmentInventory" method="AddRandomAugment"]

--- a/TheMagicApprentice/modules/handlers/DungeonHandler.cs
+++ b/TheMagicApprentice/modules/handlers/DungeonHandler.cs
@@ -62,6 +62,21 @@ public partial class DungeonHandler : Node
 		LoadRoom(Dungeon.CurrentRoomPosition, Direction.DOWN);
 	}
 
+	/**
+	Reloads the dungeon by relabeling all rooms as not cleared and loading again into the first room
+	*/
+	public void ReloadDungeon()
+	{	
+		// reset the rooms
+		foreach (Room room in Dungeon.Layout.Values)
+		{
+			room.IsCleared = false;
+			room.IsVisited = false;
+		}
+
+		LoadRoom(Dungeon.EntrancePosition, Direction.DOWN); // load into the first room
+	}
+
 	private void CheckRoomHandler()
 	{
 		if (RoomHandler == null)

--- a/TheMagicApprentice/modules/handlers/MenuManager.cs
+++ b/TheMagicApprentice/modules/handlers/MenuManager.cs
@@ -27,6 +27,7 @@ public partial class MenuManager : Node
 		DungeonSelection,
 		DungeonClearMenu,
 		NewGameMenu,
+		PlayerDeathMenu,
 	}
 
 	/**
@@ -41,7 +42,8 @@ public partial class MenuManager : Node
 		{ MenuType.SettingsMenu, "res://modules/ui/settings_menu/settings_menu.tscn" },
 		{ MenuType.DungeonSelection, "res://modules/ui/dungeon_selection/dungeon_selection.tscn" },
 		{ MenuType.DungeonClearMenu, "res://modules/ui/dungeon_clear_menu/dungeon_clear_menu.tscn" },
-		{ MenuType.NewGameMenu, "res://modules/ui/new_game_menu/new_game_menu.tscn"}
+		{ MenuType.NewGameMenu, "res://modules/ui/new_game_menu/new_game_menu.tscn"},
+		{ MenuType.PlayerDeathMenu, "res://modules/ui/player_death_menu/player_death_menu.tscn"},
 		// Add other menu types and their scene paths here
 	};
 	

--- a/TheMagicApprentice/modules/ui/player_death_menu/PlayerDeathMenu.cs
+++ b/TheMagicApprentice/modules/ui/player_death_menu/PlayerDeathMenu.cs
@@ -1,0 +1,44 @@
+using Godot;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+
+public partial class PlayerDeathMenu : BaseMenu
+{
+	/**
+	Gets called when the player presses the Exit Dungeon button.
+	Simply calls ExitDungeon using CallDeferred to avoid problems
+	*/
+	public void OnExitDungeonButtonPressed()
+	{
+		CallDeferred(nameof(ExitDungeon));
+	}
+
+	/**
+	Gets called when the player presses the Try Again button.
+	Simply calls TryAgain using CallDeferred to avoid problems
+	*/
+	public void OnTryAgainButtonPressed()
+	{
+		CallDeferred(nameof(TryAgain));
+	}
+
+	/**
+	Exit the dungeon by setting the root menu to mainHub
+	*/
+	private void ExitDungeon()
+	{
+		SetRootMenu(MenuManager.MenuType.MainHub);
+	}
+
+	/**
+	Try again by resetting player hp and reloading the dungeon
+	*/
+	private void TryAgain()
+	{
+		(GetTree().GetFirstNodeInGroup(Globals.PlayerGroup) as Player).ResetPlayerHP();
+		(GetTree().GetFirstNodeInGroup("dungeon_handler") as DungeonHandler).ReloadDungeon();
+
+		// finally pop this menu
+		PopMenu();
+	}
+}

--- a/TheMagicApprentice/modules/ui/player_death_menu/player_death_menu.tscn
+++ b/TheMagicApprentice/modules/ui/player_death_menu/player_death_menu.tscn
@@ -1,0 +1,54 @@
+[gd_scene load_steps=3 format=3 uid="uid://c6yfxxx3vhadn"]
+
+[ext_resource type="Script" path="res://modules/ui/player_death_menu/PlayerDeathMenu.cs" id="1_pingk"]
+[ext_resource type="Theme" uid="uid://b5xmy0ocd4tfb" path="res://assets/themes/ingame_inventory_theme.tres" id="2_yw7hi"]
+
+[node name="PlayerDeathMenu" type="CanvasLayer"]
+script = ExtResource("1_pingk")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 100
+theme_override_constants/margin_top = 100
+theme_override_constants/margin_right = 100
+theme_override_constants/margin_bottom = 100
+
+[node name="Panel" type="PanelContainer" parent="MarginContainer"]
+layout_mode = 2
+theme = ExtResource("2_yw7hi")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/Panel"]
+layout_mode = 2
+theme_override_constants/separation = 50
+alignment = 1
+
+[node name="RichTextLabel" type="RichTextLabel" parent="MarginContainer/Panel/VBoxContainer"]
+layout_mode = 2
+bbcode_enabled = true
+text = "[center][font_size={40}][b][color=dark_red]YOU DIED"
+fit_content = true
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/Panel/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 30
+alignment = 1
+
+[node name="TryAgainButton" type="Button" parent="MarginContainer/Panel/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(120, 40)
+layout_mode = 2
+text = "Try Again"
+
+[node name="ExitDungeonButton" type="Button" parent="MarginContainer/Panel/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(120, 40)
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+text = "Exit Dungeon
+"
+
+[connection signal="pressed" from="MarginContainer/Panel/VBoxContainer/HBoxContainer/TryAgainButton" to="." method="OnTryAgainButtonPressed"]
+[connection signal="pressed" from="MarginContainer/Panel/VBoxContainer/HBoxContainer/ExitDungeonButton" to="." method="OnExitDungeonButtonPressed"]


### PR DESCRIPTION
- Added the Healthbar to player scene and connected everything. 
- Created Player Death Menu that pops up when player dies. Allows retrying the dungeon or exiting.
- Added function to DungeonHandler that resets the current dungeon.